### PR TITLE
Update DefaultDockerClient.java

### DIFF
--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -2871,9 +2871,14 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       return "null";
     }
     try {
+      return java.util.Base64.getUrlEncoder().encodeToString(ObjectMapperProvider
+                                       .objectMapper()
+                                       .writeValueAsBytes(registryAuth));
+      /** original code
       return Base64.encodeBase64String(ObjectMapperProvider
                                        .objectMapper()
                                        .writeValueAsBytes(registryAuth));
+                                       **/
     } catch (JsonProcessingException ex) {
       throw new DockerException("Could not encode X-Registry-Auth header", ex);
     }


### PR DESCRIPTION
Replaced the apache Base64 encoder with java.util.Base64 encoder and encoding url safe. This fixes authentication error during image push to azure with service principals